### PR TITLE
1.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "fetch-request-node",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fetch-request-node",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "dependencies": {
-        "error-message-utils": "^1.1.2",
+        "error-message-utils": "^1.1.3",
         "web-utils-kit": "^1.0.5"
       },
       "devDependencies": {
@@ -1971,9 +1971,9 @@
       }
     },
     "node_modules/error-message-utils": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/error-message-utils/-/error-message-utils-1.1.2.tgz",
-      "integrity": "sha512-IdxB7iL6cGEv/2NXTTh1OXKkZXhcPhFbXwPY/ytFSblSV81GjmYyI8w172UU+nl5Qqgz/EmlRgAj7Dj1mCkDbA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/error-message-utils/-/error-message-utils-1.1.3.tgz",
+      "integrity": "sha512-8zpjXZHHdO0cNb5WHCHXM+cRMJJcMw033NYzchnhv/Lo/h6no5ajM6D1rWyMNzDFZhMv6xlvjGbB7u28yB8XfA==",
       "license": "MIT"
     },
     "node_modules/es-abstract": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-request-node",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "The fetch-request-node package makes working with external APIs simple and efficient. This intuitive wrapper leverages the power of the Fetch API, providing a clean and concise interface for your API interactions.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -42,7 +42,7 @@
     "vitest": "^1.6.1"
   },
   "dependencies": {
-    "error-message-utils": "^1.1.2",
+    "error-message-utils": "^1.1.3",
     "web-utils-kit": "^1.0.5"
   }
 }

--- a/src/index.test-unit.ts
+++ b/src/index.test-unit.ts
@@ -35,11 +35,13 @@ describe('fetch-request', () => {
       const data = { success: true };
       vi.stubGlobal('fetch', vi.fn(async () => ({
         status: 200,
+        statusText: 'OK',
         headers,
         json: () => Promise.resolve(data),
       })));
       await expect(send('https://www.google.com')).resolves.toStrictEqual({
         code: 200,
+        statusText: 'OK',
         headers,
         data,
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ const send = async <T>(
   // return the request's response
   return {
     code: res.status,
+    statusText: res.statusText,
     headers: res.headers,
     data: await extractResponseData<T>(res, opts.responseDataType),
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/indent */
 /* eslint-disable no-console */
+import { extractMessage } from 'error-message-utils';
 import {
   IRequestInput,
   IRequestMethod,
@@ -12,6 +13,7 @@ import {
   buildOptions,
   buildRequest,
   extractResponseData,
+  extractErrorMessageFromResponseBody,
 } from './utils/utils.js';
 import { validateResponse } from './validations/validations.js';
 
@@ -46,21 +48,31 @@ const send = async <T>(
   // send the request
   const res = await fetch(req);
 
-  // validate the response
-  validateResponse(req, res, opts);
+  // if the validation succeeds, build the response. Otherwise, try to extract the cause of the
+  // error from the body of the response
+  try {
+    // validate the response
+    validateResponse(req, res, opts);
 
-  // print a warning in case the request was redirected
-  if (res.redirected) {
-    console.warn(`The request sent to '${req.url}' was redirected. Please update the implementation to avoid future redirections.`);
+    // print a warning in case the request was redirected
+    if (res.redirected) {
+      console.warn(`The request sent to '${req.url}' was redirected. Please update the implementation to avoid future redirections.`);
+    }
+
+    // return the request's response
+    return {
+      code: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+      data: await extractResponseData<T>(res, opts.responseDataType),
+    };
+  } catch (e) {
+    const cause = await extractErrorMessageFromResponseBody(res);
+    if (cause) {
+      throw new Error(extractMessage(e), { cause });
+    }
+    throw e;
   }
-
-  // return the request's response
-  return {
-    code: res.status,
-    statusText: res.statusText,
-    headers: res.headers,
-    data: await extractResponseData<T>(res, opts.responseDataType),
-  };
 };
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -81,6 +81,9 @@ interface IRequestResponse<T> {
   // the HTTP status code extracted from the Response
   code: number;
 
+  // the message associated with the status code
+  statusText: string;
+
   // the Response's Headers. Useful as some service providers attach important info in the headers
   headers: Headers;
 

--- a/src/utils/utils.test-unit.ts
+++ b/src/utils/utils.test-unit.ts
@@ -7,12 +7,12 @@ import { buildOptions, buildRequest, extractResponseData } from './utils.js';
  *                                            HELPERS                                             *
  ************************************************************************************************ */
 
-const rs = (): Response => (<any>{
-  arrayBuffer: vi.fn(() => Promise.resolve()),
-  blob: vi.fn(() => Promise.resolve()),
-  formData: vi.fn(() => Promise.resolve()),
-  json: vi.fn(() => Promise.resolve()),
-  text: vi.fn(() => Promise.resolve()),
+const rs = (data?: any): Response => (<any>{
+  arrayBuffer: vi.fn(() => Promise.resolve(data)),
+  blob: vi.fn(() => Promise.resolve(data)),
+  formData: vi.fn(() => Promise.resolve(data)),
+  json: vi.fn(() => Promise.resolve(data)),
+  text: vi.fn(() => Promise.resolve(data)),
 });
 
 
@@ -165,6 +165,32 @@ describe('buildRequest', () => {
 
 
 describe('extractResponseData', () => {
+  test('can extract any data type', async () => {
+    const res = rs();
+    await extractResponseData(res, 'arrayBuffer');
+    expect(res.arrayBuffer).toHaveBeenCalledOnce();
+    await extractResponseData(res, 'arrayBuffer');
+    expect(res.arrayBuffer).toHaveBeenCalledTimes(2);
+    await extractResponseData(res, 'blob');
+    expect(res.blob).toHaveBeenCalledOnce();
+    await extractResponseData(res, 'formData');
+    expect(res.formData).toHaveBeenCalledOnce();
+    await extractResponseData(res, 'json');
+    expect(res.json).toHaveBeenCalledOnce();
+    await extractResponseData(res, 'text');
+    expect(res.text).toHaveBeenCalledOnce();
+  });
+
+  test('throws an error if an invalid dtype is provided', async () => {
+    await expect(() => extractResponseData(rs(), <IResponseDataType>'nonsense')).rejects.toThrowError(ERRORS.INVALID_RESPONSE_DTYPE);
+  });
+});
+
+
+
+
+
+describe('extractErrorMessageFromResponseBody', () => {
   test('can extract any data type', async () => {
     const res = rs();
     await extractResponseData(res, 'arrayBuffer');

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,9 @@
-import { encodeError, isEncodedError } from 'error-message-utils';
+import {
+  encodeError,
+  extractMessage,
+  isDefaultErrorMessage,
+  isEncodedError,
+} from 'error-message-utils';
 import { isArrayValid, isObjectValid } from 'web-utils-kit';
 import { ERRORS } from '../shared/errors.js';
 import {
@@ -178,6 +183,23 @@ const extractResponseData = async <T>(
   }
 };
 
+/**
+ * Attempts to extract the error message from the response object. If it fails, it returns
+ * undefined.
+ * @param res
+ * @returns Promise<string | undefined>
+ * @stable
+ */
+const extractErrorMessageFromResponseBody = async (res: Response): Promise<string | undefined> => {
+  try {
+    const erroredBody = await res.json();
+    const message = extractMessage(erroredBody);
+    return isDefaultErrorMessage(message) ? undefined : message;
+  } catch (e) {
+    return undefined;
+  }
+};
+
 
 
 
@@ -212,6 +234,7 @@ export {
 
   // response helpers
   extractResponseData,
+  extractErrorMessageFromResponseBody,
 
   // misc helpers
   buildOptions,


### PR DESCRIPTION
- Include `statusText` property to `IRequestResponse`
- Whenever a request fails, it attempts to extract the reason from the body. If found, it adds it as the cause in the Error instance. Otherwise, it **re-throws** the error